### PR TITLE
Update Jinja2 dependency due to CVE-2019-10906

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ bokeh==0.12.1
 certifi==2017.4.17
 cycler==0.10.0
 futures==3.0.5
-Jinja2==2.8.1
+Jinja2==2.10.1
 MarkupSafe==0.23
 matplotlib==1.5.1
 numpy==1.11.1


### PR DESCRIPTION
See https://nvd.nist.gov/vuln/detail/CVE-2019-10906